### PR TITLE
1.3.17: Sequel接続プール設定を可変化 (#97)

### DIFF
--- a/config/lib.yaml
+++ b/config/lib.yaml
@@ -6,7 +6,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/ginseng-postgres
-  version: 1.3.16
+  version: 1.3.17
 postgres:
   dsn: postgres://postgres:password@localhost:5432/test
   slow_query:

--- a/lib/ginseng/postgres/database.rb
+++ b/lib/ginseng/postgres/database.rb
@@ -8,6 +8,7 @@ module Ginseng
     class Database
       include Singleton
       include Package
+
       attr_reader :connection
 
       def initialize
@@ -15,7 +16,11 @@ module Ginseng
         @logger = logger_class.new
         dsn = database_class.dsn
         raise DatabaseError, 'Invalid DSN' unless dsn.valid?
-        @connection = Sequel.connect(dsn.to_s)
+        @connection = Sequel.connect(
+          dsn.to_s,
+          max_connections: (@config['/postgres/pool/size'] rescue 4),
+          pool_timeout: (@config['/postgres/pool/timeout'] rescue 5),
+        )
         @connection.convert_infinite_timestamps = :nil
       rescue => e
         @logger.error(error: e)


### PR DESCRIPTION
## Summary

- \`/postgres/pool/size\` で \`max_connections\` を指定可能に (デフォルト 4)
- \`/postgres/pool/timeout\` で \`pool_timeout\` を指定可能に (デフォルト 5)
- 未設定時は Sequel デフォルト互換なので既存環境への影響なし

Closes #97

## Why

ダウンストリームの mulukhiya-toot-proxy（Mastodon プロキシ）で、並走ワーカー + 連合からの API リクエスト多重時に \`Sequel::PoolTimeout (timeout: 5.0)\` を踏むケースが頻発し、お知らせボットの Postgres ヘルスチェック誤報の原因となっている。実際の PostgreSQL 側は健全だが、Sequel クライアント側プール 4 枠の不足がボトルネック。

詳細: pooza/mulukhiya-toot-proxy#4232

## Test plan

- [x] rubocop 通過
- [ ] CI グリーン（GitHub Actions）
- [ ] ダウンストリーム mulukhiya-toot-proxy で bundle update → 動作確認